### PR TITLE
cmake: install llibs in arch libdir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ configure_file (
   "${CMAKE_CURRENT_BINARY_DIR}/include/libecpint/config.hpp"
 )
 
+include(GNUInstallDirs)
 include(ExternalProject)
 include(external/ImportPugiXML.cmake)
 message(${PUGIXML_INCLUDE_DIR})

--- a/external/Faddeeva/CMakeLists.txt
+++ b/external/Faddeeva/CMakeLists.txt
@@ -8,4 +8,4 @@ target_include_directories(Faddeeva
 if(NOT BUILD_SHARED_LIBS)
   set_property(TARGET Faddeeva PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()
-install(TARGETS Faddeeva EXPORT ecpintTargets DESTINATION lib)
+install(TARGETS Faddeeva EXPORT ecpintTargets DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,7 +59,7 @@ target_link_libraries(ecpint
 #  Install
 # =========
 
-install(TARGETS ecpint EXPORT ecpintTargets DESTINATION lib)
+install(TARGETS ecpint EXPORT ecpintTargets DESTINATION ${CMAKE_INSTALL_LIBDIR})
 include(CMakePackageConfigHelpers)
 # Version file
 write_basic_package_version_file(
@@ -71,7 +71,7 @@ write_basic_package_version_file(
 configure_package_config_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/config.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/ecpint-config.cmake
-  INSTALL_DESTINATION lib/cmake/ecpint
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ecpint
 )
 # Targets files
 export(
@@ -81,13 +81,13 @@ export(
 install(
   EXPORT ecpintTargets
   FILE ecpint-targets.cmake
-  DESTINATION lib/cmake/ecpint
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ecpint
 )
 install(
   FILES
     ${CMAKE_CURRENT_BINARY_DIR}/ecpint-config.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/ecpint-config-version.cmake
-  DESTINATION lib/cmake/ecpint
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ecpint
 )
 
-install(TARGETS ecpint DESTINATION lib)
+install(TARGETS ecpint DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
Basically using `lib64` instead of `lib` on 640bit archs.