### PR TITLE
Fixes based off packaging for Fedora-rawhide

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ project( libecpint
          VERSION 1.0
          LANGUAGES C CXX)
 
+set(API_VERSION 1)
 set (CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
 # code generator variables

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ configure_file (
   "${CMAKE_CURRENT_BINARY_DIR}/include/libecpint/config.hpp"
 )
 
+include(GNUInstallDirs)
 include(ExternalProject)
 include(external/ImportPugiXML.cmake)
 message(${PUGIXML_INCLUDE_DIR})

--- a/external/Faddeeva/CMakeLists.txt
+++ b/external/Faddeeva/CMakeLists.txt
@@ -8,4 +8,4 @@ target_include_directories(Faddeeva
 if(NOT BUILD_SHARED_LIBS)
   set_property(TARGET Faddeeva PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()
-install(TARGETS Faddeeva EXPORT ecpintTargets DESTINATION lib)
+install(TARGETS Faddeeva EXPORT ecpintTargets DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/external/Faddeeva/CMakeLists.txt
+++ b/external/Faddeeva/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(Faddeeva Faddeeva.cpp)
 set_property(TARGET Faddeeva PROPERTY CXX_STANDARD 11)
+set_target_properties(Faddeeva PROPERTIES SOVERSION ${API_VERSION})
 target_include_directories(Faddeeva
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,7 +60,7 @@ target_link_libraries(ecpint
 #  Install
 # =========
 
-install(TARGETS ecpint EXPORT ecpintTargets DESTINATION lib)
+install(TARGETS ecpint EXPORT ecpintTargets DESTINATION ${CMAKE_INSTALL_LIBDIR})
 include(CMakePackageConfigHelpers)
 # Version file
 write_basic_package_version_file(
@@ -72,7 +72,7 @@ write_basic_package_version_file(
 configure_package_config_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/config.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/ecpint-config.cmake
-  INSTALL_DESTINATION lib/cmake/ecpint
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ecpint
 )
 # Targets files
 export(
@@ -82,13 +82,13 @@ export(
 install(
   EXPORT ecpintTargets
   FILE ecpint-targets.cmake
-  DESTINATION lib/cmake/ecpint
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ecpint
 )
 install(
   FILES
     ${CMAKE_CURRENT_BINARY_DIR}/ecpint-config.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/ecpint-config-version.cmake
-  DESTINATION lib/cmake/ecpint
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ecpint
 )
 
-install(TARGETS ecpint DESTINATION lib)
+install(TARGETS ecpint DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,10 +14,11 @@ target_include_directories(generate
     ${CMAKE_CURRENT_BINARY_DIR}/../include/libecpint
 )
 
-execute_process(COMMAND mkdir -p "${CMAKE_CURRENT_BINARY_DIR}/generated")
-execute_process(COMMAND cp "${CMAKE_CURRENT_SOURCE_DIR}/generated/ecpint_gen.part" "${CMAKE_CURRENT_BINARY_DIR}/generated")
-execute_process(COMMAND cp "${CMAKE_CURRENT_SOURCE_DIR}/generated/qgen.part" "${CMAKE_CURRENT_BINARY_DIR}/generated")
-execute_process(COMMAND python "${CMAKE_CURRENT_SOURCE_DIR}/makelist.py" "${LIBECPINT_MAX_L}" "${CMAKE_CURRENT_BINARY_DIR}")
+file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/generated")
+file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/generated/ecpint_gen.part" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/generated")
+file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/generated/qgen.part" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/generated")
+find_package (Python COMPONENTS Interpreter)
+execute_process(COMMAND ${Python_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/makelist.py" "${LIBECPINT_MAX_L}" "${CMAKE_CURRENT_BINARY_DIR}")
 file(READ "${CMAKE_CURRENT_BINARY_DIR}/qlist.txt" GENERATED_SOURCES)
 STRING(REGEX REPLACE "\n" ";" GENERATED_SOURCES "${GENERATED_SOURCES}")
 add_custom_command(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,7 @@ if(NOT BUILD_SHARED_LIBS)
 endif()
 
 set_property(TARGET ecpint PROPERTY CXX_STANDARD 11)
+set_target_properties(ecpint PROPERTIES SOVERSION ${API_VERSION})
 target_include_directories(ecpint
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/libecpint>

--- a/src/lib/bessel.cpp
+++ b/src/lib/bessel.cpp
@@ -51,7 +51,7 @@ namespace libecpint {
 			K[i] = new double[lMax + TAYLOR_CUT + 1];
 			dK[i] = new double*[TAYLOR_CUT + 1];
 			for (int j = 0; j < TAYLOR_CUT + 1; j++)
-				dK[i][j] = new double[lMax + TAYLOR_CUT];
+				dK[i][j] = new double[lMax + TAYLOR_CUT + 1];
 		}
 		C = new double[lMax+TAYLOR_CUT];
 	
@@ -121,7 +121,7 @@ namespace libecpint {
 		// K_l^(n+1) = C_l K_(l-1)^(n) + (C_l + 1/(2l+1))K_(l+1)^(n) - K_l^(n)
 		for (int ix = 0; ix < N+1; ix++) {
 			// Copy K values into dK
-			for (int l = 0; l < lMax+TAYLOR_CUT; l++)
+			for (int l = 0; l <= lMax+TAYLOR_CUT; l++)
 				dK[ix][0][l] = K[ix][l];
 	    	
 			// Then the rest


### PR DESCRIPTION
This merges the 3 pull requests from @junghans with minor changes to the CMake files, and fixes #9 where there were memory leaks in left_shell_derivative and left_shell_second_derivative. These leaks did not affect the values of derivatives, only stability under certain build systems. 