### PR TITLE
replaced C-style arrays with std::vector

### DIFF
--- a/include/libecpint/bessel.hpp
+++ b/include/libecpint/bessel.hpp
@@ -51,9 +51,9 @@ namespace libecpint {
 		int order; ///< Order to which the Bessel series is expanded
 		double scale; ///< N/16.0
 	
-		double **K; ///< Bessel function values
-		double ***dK; ///< Bessel function derivatives
-		double *C; ///< Coefficients of derivatives of the Bessel function
+		std::vector<std::vector<double>> K; ///< Bessel function values
+		std::vector<std::vector<std::vector<double>>> dK; ///< Bessel function derivatives
+		std::vector<double> C; ///< Coefficients of derivatives of the Bessel function
 	
 		/**
 		* Pretabulates the Bessel function (and derivs) to a given accuracy.
@@ -69,8 +69,6 @@ namespace libecpint {
 		/// Specified constructor. Will call init with given arguments.
 		BesselFunction(int lMax, int N, int order, double accuracy);
 		
-		/// Destructor, cleans up K and C
-		~BesselFunction();
 	
 		/**
 		* Initialises and pretabulates the BesselFunction up to the given angular momentum. 

--- a/src/lib/bessel.cpp
+++ b/src/lib/bessel.cpp
@@ -45,25 +45,15 @@ namespace libecpint {
 		scale = N/16.0;
 	
 		// Allocate arrays
-		K = new double*[N+1];
-		dK = new double**[N+1];
-		for (int i = 0; i < N+1; i++) {
-			K[i] = new double[lMax + TAYLOR_CUT + 1];
-			dK[i] = new double*[TAYLOR_CUT + 1];
-			for (int j = 0; j < TAYLOR_CUT + 1; j++)
-				dK[i][j] = new double[lMax + TAYLOR_CUT + 1];
-		}
-		C = new double[lMax+TAYLOR_CUT];
-	
+
+		K=std::vector<std::vector<double>>(N+1,std::vector<double>(lMax + TAYLOR_CUT + 1,0.0));
+		C=std::vector<double>(lMax+TAYLOR_CUT,0.0);
+		dK=std::vector<std::vector<std::vector<double>>>(N+1,std::vector<std::vector<double>>(lMax + TAYLOR_CUT + 1,std::vector<double>(lMax + TAYLOR_CUT + 1,0.0)));
 		// Tabulate values
 		tabulate(accuracy);
 	}
 
-	BesselFunction::~BesselFunction() {
-		free(K);
-		free(dK);
-		free(C);
-	}
+
 
 	// Tabulate the bessel function values
 	int BesselFunction::tabulate(const double accuracy) {

--- a/src/lib/ecp.cpp
+++ b/src/lib/ecp.cpp
@@ -67,6 +67,7 @@ namespace libecpint {
 		gaussians = other.gaussians;
 		N = other.N;
 		L = other.L;
+		atom_id=other.atom_id;
 		min_exp = other.min_exp;
 		for (int i = 0; i < LIBECPINT_MAX_L + 1; i++) {
 			min_exp_l[i] = other.min_exp_l[i];


### PR DESCRIPTION
I got `mismatched free/delete` errors in bessel.cpp

as `<vector>` is included anyway I just replaced the `double***` with nested `std::vectors`, performance wise it should not matter otherwise I can also replace them with the 2-index,3-index classes. 

Also fixed the copy constructor of `ECP` object. 