### PR TITLE
added clang-format structure

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,47 @@
+---
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+ConstructorInitializerIndentWidth: 4
+AlignEscapedNewlinesLeft: true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AlwaysBreakTemplateDeclarations: true
+AlwaysBreakBeforeMultilineStrings: true
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+BreakBeforeBinaryOperators: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BinPackParameters: true
+ColumnLimit:     80
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+DerivePointerBinding: true
+ExperimentalAutoDetectBinPacking: false
+IndentCaseLabels: true
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 60
+PenaltyBreakString: 1000
+PenaltyBreakFirstLessLess: 120
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerBindsToType: true
+SpacesBeforeTrailingComments: 2
+Cpp11BracedListStyle: true
+Standard:        Auto
+IndentWidth:     2
+TabWidth:        8
+UseTab:          Never
+BreakBeforeBraces: Attach
+IndentFunctionDeclarationAfterType: true
+SpacesInParentheses: false
+SpacesInAngles:  false
+SpaceInEmptyParentheses: false
+SpacesInCStyleCastParentheses: false
+SpaceAfterControlStatementKeyword: true
+SpaceBeforeAssignmentOperators: true
+ContinuationIndentWidth: 4
+...
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,24 @@ if (LIBECPINT_BUILD_DOCS)
   add_subdirectory(doc)
 endif()
 
+find_package(CLANG_FORMAT 11 EXACT)
+if(CLANG_FORMAT_FOUND)
+set(FORMAT_SOURCES)
+list(APPEND FORMAT_SUBDIRS tests "include/libecpint" src)
+foreach(DIR ${FORMAT_SUBDIRS})
+    set(ABS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/${DIR})
+    file(GLOB_RECURSE ${DIR}_SOURCES ${ABS_DIR}/*.cpp ${ABS_DIR}/*.hpp)
+    list(APPEND FORMAT_SOURCES ${${DIR}_SOURCES})
+  endforeach()
+    file(GLOB FORMAT_INCLUDES LIST_DIRECTORIES false ${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp)
+    list (APPEND FORMAT_SOURCES ${FORMAT_INCLUDES})
+    add_custom_target(format
+    COMMAND ${CLANG_FORMAT_EXECUTABLE} -i -style=file ${FORMAT_SOURCES}
+    DEPENDS ${FORMAT_SOURCES})
+endif()
+
+
+
 install (DIRECTORY include/libecpint DESTINATION include)
 install (FILES include/libecpint.hpp DESTINATION include)
 install (FILES "${CMAKE_CURRENT_BINARY_DIR}/include/libecpint/config.hpp" DESTINATION include/libecpint)

--- a/cmake/FindCLANG_FORMAT.cmake
+++ b/cmake/FindCLANG_FORMAT.cmake
@@ -1,0 +1,71 @@
+#
+#    Copyright (c) 2020 Robert Shaw
+#		 This file is a part of Libecpint.
+#
+#    Permission is hereby granted, free of charge, to any person obtaining
+#    a copy of this software and associated documentation files (the
+#    "Software"), to deal in the Software without restriction, including
+#    without limitation the rights to use, copy, modify, merge, publish,
+#    distribute, sublicense, and/or sell copies of the Software, and to
+#    permit persons to whom the Software is furnished to do so, subject to
+#    the following conditions:
+#
+#    The above copyright notice and this permission notice shall be
+#    included in all copies or substantial portions of the Software.
+#
+#    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+#    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+#    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+#    LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+#    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+#    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+
+find_program(CLANG_FORMAT_EXECUTABLE
+             NAMES clang-format
+                   clang-format-11
+                   clang-format-10
+                   clang-format-9
+                   clang-format-8
+                   clang-format-7
+                   clang-format-6.0
+                   clang-format-5.0
+                   clang-format-4.0
+                   clang-format-3.9
+                   clang-format-3.8
+                   clang-format-3.7
+                   clang-format-3.6
+                   clang-format-3.5
+                   clang-format-3.4
+                   clang-format-3.3
+             DOC "clang-format executable")
+mark_as_advanced(CLANG_FORMAT_EXECUTABLE)
+
+# Extract version from command "clang-format -version"
+if(CLANG_FORMAT_EXECUTABLE)
+  execute_process(COMMAND ${CLANG_FORMAT_EXECUTABLE} -version
+                  OUTPUT_VARIABLE clang_format_version
+                  ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  if(clang_format_version MATCHES "^.*clang-format version .*")
+    # clang_format_version sample: "clang-format version 3.9.1-4ubuntu3~16.04.1
+    # (tags/RELEASE_391/rc2)"
+    string(REGEX
+           REPLACE "^.*clang-format version ([.0-9]+).*"
+                   "\\1"
+                   CLANG_FORMAT_VERSION
+                   "${clang_format_version}")
+    # CLANG_FORMAT_VERSION sample: "3.9.1"
+  else()
+    set(CLANG_FORMAT_VERSION 0.0)
+  endif()
+else()
+  set(CLANG_FORMAT_VERSION 0.0)
+endif()
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set CLANG_FORMAT_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(CLANG_FORMAT REQUIRED_VARS CLANG_FORMAT_EXECUTABLE VERSION_VAR CLANG_FORMAT_VERSION)


### PR DESCRIPTION
This is the start to https://github.com/robashaw/libecpint/issues/28

The next step would be to pick a format specification, you like. This format is specified in the .clang-format file. 

This can help to determine what you like. https://zed0.co.uk/clang-format-configurator/

Afterwards the whole codebase can be reformatted using a simple `make format`. 

In a last step the CI could check the formatting and reject PRs, which are not properly formatted. 
@junghans can probably comment on that. 


