### PR TITLE
cmake: update version in project()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
 # define project
 project( libecpint
-         VERSION 1.0
+         VERSION 1.0.5
          LANGUAGES C CXX)
 
 set(API_VERSION 1)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Libecpint 1.0.4
+## Libecpint 1.0.5
 
 [![Build Status](https://dev.azure.com/robertshaw383/libecpint/_apis/build/status/robashaw.libecpint?branchName=master)](https://dev.azure.com/robertshaw383/libecpint/_build/latest?definitionId=2&branchName=master)
 [![codecov](https://codecov.io/gh/robashaw/libecpint/branch/master/graph/badge.svg)](https://codecov.io/gh/robashaw/libecpint)

--- a/doc/doxygen/Doxyfile
+++ b/doc/doxygen/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = LIBECPINT
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 1.0
+PROJECT_NUMBER         = 1.0.5
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a


### PR DESCRIPTION
The version in project() is used by cmake when exporting the
targets.

I also fixed the version in a couple other places.

fix #31 