### PR TITLE
Small fixes for Intel compilers

### DIFF
--- a/include/generate.hpp
+++ b/include/generate.hpp
@@ -125,7 +125,7 @@ namespace libecpint {
 			int f6 = CA == s.CA ? 1 : 0;
 			int f7 = CB == s.CB ? 1 : 0; 
 		
-			return {f1, f2, f3, f4, f5, f6, f7};  
+			return Heptuple{f1, f2, f3, f4, f5, f6, f7};  
 		}
 	
 		/// Prints out a SumTerm without compressing the indices - currently preferred 

--- a/src/generate.cpp
+++ b/src/generate.cpp
@@ -202,7 +202,7 @@ void generate_lists(int LA, int LB, int lam, libecpint::AngularIntegral& angInts
 		std::vector<Triple> radial_A, radial_B; 
 		for (const Triple& t : radial_triples) {
 			if (std::get<1>(t) <= std::get<2>(t)) radial_A.push_back(t);  
-			else radial_B.push_back({std::get<0>(t), std::get<2>(t), std::get<1>(t)});
+			else radial_B.push_back(Triple{std::get<0>(t), std::get<2>(t), std::get<1>(t)});
 		}
 		
 		// Compute the correctly ordered radials first
@@ -211,7 +211,7 @@ void generate_lists(int LA, int LB, int lam, libecpint::AngularIntegral& angInts
 		for (Triple& t : radial_A) {
 			if (!first) outfile << "," << std::endl; 
 			else first = false;
-			outfile << "\t\t{" + std::to_string(std::get<0>(t)) + ", "
+			outfile << "\t\tTriple{" + std::to_string(std::get<0>(t)) + ", "
 				+ std::to_string(std::get<1>(t)) + ", " 
 					+ std::to_string(std::get<2>(t)) + "}"; 
 		}
@@ -226,7 +226,7 @@ void generate_lists(int LA, int LB, int lam, libecpint::AngularIntegral& angInts
 		for (Triple& t : radial_B) {
 			if (!first) outfile << "," << std::endl; 
 			else first = false; 
-			outfile << "\t\t{" + std::to_string(std::get<0>(t)) + ", "
+			outfile << "\t\tTriple{" + std::to_string(std::get<0>(t)) + ", "
 				+ std::to_string(std::get<1>(t)) + ", " 
 					+ std::to_string(std::get<2>(t)) + "}"; 
 		}


### PR DESCRIPTION
It seems that clang and GCC are happy with the curly bracket notation used in a few places in the code, interpreting is as uniform initialisation.  However, Intel seems to be interpreting them as an `initializer_list` and chokes when a corresponding constructor is not found.  These small changes allow the code to compile with Intel, by more explicitly indicating that uniform initialisation is what's being requested.  The tests all pass for me with Intel 19.1 on Linux.

For posterity, I had to add `-DCMAKE_CXX_FLAGS="-std=c++11 -gxx-name=/v/apps/gcc/5.4.0/bin/g++"` to get it working.  The base compiler on our cluster is GCC 4.8, which lacks full C++11 support, so I point Intel to a slightly newer version with the `-gxx-name` argument.  The `-std=c++11` might be best handled by defining the required standard in the CMake files.  Pinging @loriab in case she has encountered similar problems while trying to get this running with Psi4.