### PR TITLE
Allow compiling without pugixml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 *~
 *.out
 *.x
+.ccls-cache/
+.clangd/
 .DS_Store
 build/*
 _example2/*
@@ -11,3 +13,4 @@ build_highl/*
 doc/doxygen/html/*
 doc/doxygen/latex/*
 doc/sphinx/build/*
+compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,13 @@ configure_file (
 
 include(GNUInstallDirs)
 include(ExternalProject)
-include(external/ImportPugiXML.cmake)
-message(${PUGIXML_INCLUDE_DIR})
+option(LIBECPINT_USE_PUGIXML "Use pugixml and build file reading routines." ON)
+if (LIBECPINT_USE_PUGIXML)
+  include(external/ImportPugiXML.cmake)
+  add_compile_definitions(HAS_PUGIXML)
+else()
+  message(STATUS "pugixml not configured; reading ECP definitions from files is disabled.")
+endif()
 
 add_subdirectory(external)
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,11 @@ cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 if(NOT CMAKE_BUILD_TYPE)
   message(STATUS "No build type specified. Will build Release")
   set (CMAKE_BUILD_TYPE Release CACHE STRING "Build type (Release/Debug/RelWithDebInfo)")
+else()
+  string(TOUPPER "${CMAKE_BUILD_TYPE}" _upper_build_type)
+  if("${_upper_build_type}" STREQUAL "DEBUG")
+    add_compile_definitions(DEBUG)
+  endif()
 endif(NOT CMAKE_BUILD_TYPE)
 
 # define project

--- a/external/ImportGTest.cmake
+++ b/external/ImportGTest.cmake
@@ -6,7 +6,7 @@ find_path(GTEST_INCLUDE_DIR gtest/gtest.h
 )
 
 if((NOT GTEST_LIBRARY) OR (NOT GTEST_INCLUDE_DIR))
-  message("Unable to find google test, cloning...")
+  message(STATUS "Unable to find google test, cloning...")
 
   # Download and unpack googletest at configure time
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/external/CMakeLists.txt.in googletest-download/CMakeLists.txt)
@@ -36,7 +36,7 @@ if((NOT GTEST_LIBRARY) OR (NOT GTEST_INCLUDE_DIR))
 
   set(GTEST_INCLUDE_DIR ${gtest_SOURCE_DIR}/include)
 else()
-  message("Found googletest")
+  message(STATUS "Found googletest: ${GTEST_INCLUDE_DIR} ${GTEST_LIBRARY}")
   add_library(gtest INTERFACE)
   target_include_directories(gtest INTERFACE ${GTEST_INCLUDE_DIR})
   target_link_libraries(gtest INTERFACE ${GTEST_LIBRARY})

--- a/external/ImportPugiXML.cmake
+++ b/external/ImportPugiXML.cmake
@@ -9,7 +9,7 @@ find_path(PUGIXML_INCLUDE_DIR pugixml.hpp
 )
 
 if((NOT PUGIXML_LIBRARY) OR (NOT PUGIXML_INCLUDE_DIR))
-  message("Unable to find pugixml, cloning...")
+  message(STATUS "Unable to find pugixml, cloning...")
 
   ExternalProject_Add(pugixml_external
     PREFIX ${EXTERNAL_BUILD_DIR}/pugixml
@@ -28,7 +28,7 @@ if((NOT PUGIXML_LIBRARY) OR (NOT PUGIXML_INCLUDE_DIR))
   set_target_properties(libpugixml PROPERTIES IMPORTED_LOCATION ${PUGIXML_LIBRARY})
 
 else()
-  message("Found pugixml")
+  message(STATUS "Found pugixml: ${PUGIXML_INCLUDE_DIR} ${PUGIXML_LIBRARY}")
   add_library(libpugixml INTERFACE)
   target_include_directories(libpugixml INTERFACE ${PUGIXML_INCLUDE_DIR})
   target_link_libraries(libpugixml INTERFACE ${PUGIXML_LIBRARY})

--- a/include/libecpint/api.hpp
+++ b/include/libecpint/api.hpp
@@ -117,6 +117,7 @@ namespace libecpint {
 		  */
 		void set_ecp_basis(int necps, const double* coords, const double* exponents, const double* coefs, const int* ams, const int* ns, const int* shell_lengths);
 		
+#ifdef HAS_PUGIXML
 		/**  Constructs an ECPBasis with ECP objects for each ECP, from the built-in ECP library.
 		  *  The order of the atoms doesn't matter, and ids will be matched to the order from set_gaussian_basis.
 		  *  It will search for the file  "share_dir + / + name + .xml"     
@@ -128,6 +129,7 @@ namespace libecpint {
 		  *  @param share_dir - the location of the share directory with the ecp library (typically "PATH/share/libecpint/xml")
 		  */
 		void set_ecp_basis_from_library(int necps, const double* coords, const int* charges, const std::vector<std::string> & names, const std::string & share_dir);
+#endif
 		
 		/**  Updates the positions of the GaussianShells.
 		  *  The order of the coordinates must match that when originally specified in set_gaussian_basis.

--- a/include/libecpint/ecp.hpp
+++ b/include/libecpint/ecp.hpp
@@ -194,7 +194,8 @@ namespace libecpint {
 		
 		/// @return the number of ECPs in basis
 		int getN() const { return N; }
-		
+
+#ifdef HAS_PUGIXML
 		/** Creates and adds an ECP object to the basis by reading from the ECP library
 		  * @param q - the atomic number of the atom
 		  * @param coords - the [x, y, z] coordinates (in bohr) of the ECP
@@ -202,6 +203,7 @@ namespace libecpint {
 		  */
 		void addECP_from_file(
 		    const int q, const std::array<double, 3> & coords, const std::string & filename);
+#endif
 	};
 
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,14 +49,15 @@ target_include_directories(ecpint
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include/libecpint>
     $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include/libecpint>
     $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>
-  PRIVATE
-    ${PUGIXML_INCLUDE_DIR}
 )
 target_link_libraries(ecpint
  PRIVATE
   Faddeeva
-  libpugixml
 )
+if(LIBECPINT_USE_PUGIXML)
+  target_include_directories(ecpint PRIVATE ${PUGIXML_INCLUDE_DIR})
+  target_link_libraries(ecpint PRIVATE libpugixml)
+endif()
 
 # =========
 #  Install

--- a/src/generate.cpp
+++ b/src/generate.cpp
@@ -52,9 +52,9 @@ void generate_lists(int LA, int LB, int lam, libecpint::AngularIntegral& angInts
 	if (!outfile.is_open())
 		std::cerr << "Problems writing to file!" << std::endl; 
 	else {
-		
+#ifdef DEBUG
 		std::cout << "Generating Q(" << LA << ", " << LB << ", " << lam << ")... " << std::flush; 
-		
+#endif
 		// Top matter
 		outfile << "// Generated as part of Libecpint, Copyright 2017 Robert A Shaw" << std::endl; 
 		outfile << "#include \"qgen.hpp\"" << std::endl; 
@@ -239,15 +239,18 @@ void generate_lists(int LA, int LB, int lam, libecpint::AngularIntegral& angInts
 		
 		if (unrolling) {
 			// Print out the unrolled angular integral code if needed
-			std::cout << "unrolling... " << std::flush; 
+#ifdef DEBUG
+			std::cout << "unrolling... " << std::flush;
+#endif
 			for (auto& term : terms) outfile << "\t" << term << std::endl; 
 		} else {
 			// Just use the generic rolled-up angular integral code
 			outfile << "\trolled_up(" << lam << ", " << LA << ", " << LB << ", radials, CA, CB, SA, SB, angint, values);" << std::endl; 
 		}
 		outfile << "}" << std::endl << "}" << std::endl << "}" << std::endl; 
-		
-		std::cout << "done." << std::endl; 
+#ifdef DEBUG
+		std::cout << "done." << std::endl;
+#endif
 		outfile.close();
 	}
 }
@@ -341,4 +344,3 @@ int main(int argc, char* argv[]) {
 	}
 	return 0; 
 }
-	

--- a/src/lib/api.cpp
+++ b/src/lib/api.cpp
@@ -64,6 +64,7 @@ namespace libecpint {
 		ecp_is_set = true;
 	}
 	
+#ifdef HAS_PUGIXML
 	void ECPIntegrator::set_ecp_basis_from_library(
       const int necps, const double* coords, const int* charges, const std::vector<std::string> & names, const std::string & share_dir) {
 		for (int i = 0; i < necps; i++) {
@@ -74,6 +75,7 @@ namespace libecpint {
 		}
 		ecp_is_set = true;
 	}
+#endif
 	
 	void ECPIntegrator::update_gaussian_basis_coords(const int nshells, const double* coords) {
 		assert(nshells == shells.size());

--- a/src/lib/ecp.cpp
+++ b/src/lib/ecp.cpp
@@ -27,8 +27,10 @@
 #include <cmath>
 #include <iostream>
 #include <algorithm>
-#include "pugixml.hpp"
 #include "mathutil.hpp"
+#ifdef HAS_PUGIXML
+#include "pugixml.hpp"
+#endif
 
 namespace libecpint {
 
@@ -136,7 +138,8 @@ namespace libecpint {
 		if (it != core_electrons.end()) core = it->second;
 		return core;
 	}
-	
+
+#ifdef HAS_PUGIXML
 	void ECPBasis::addECP_from_file(
       const int q, const std::array<double, 3> & coords, const std::string & filename) {
 		ECP newECP;
@@ -168,4 +171,5 @@ namespace libecpint {
 		newECP.sort();
 		addECP(newECP, 0);
 	}
+#endif
 }


### PR DESCRIPTION
In the event that one doesn't need to use libecpint directly to read ECP definitions from files, the pugixml dependency isn't necessary.

I couldn't decide between `HAS_PUGIXML` or `WITH_PUGIXML` for the preprocessor definition, and kind of don't like either of them. If you have a better suggestion, or prefer another way to disable compiling these routines, let me know.