### PR TITLE
Allow specifying radial integral grid sizes in ECPIntegral constructor

### DIFF
--- a/include/libecpint/ecpint.hpp
+++ b/include/libecpint/ecpint.hpp
@@ -89,8 +89,12 @@ namespace libecpint {
 		  * @param maxLB - the maximum angular momentum in the orbital basis
 		  * @param maxLU - the maximum angular momentum in the ECP basis
 		  * @param deriv - the maximum order of derivative to be calculated (TODO: derivs currently being implemented)
+		  * @param tol - the tolerance for convergence of radial integrals (defaults to 1e-15)
+		  * @param small - the maximum number of quadrature points for the small radial integration grid (default 256, minimum recommended)
+		  * @param large - the maximum number of quadrature points for the large radial integration grid (default 1024, minimum recommended)
 		  */ 
-		ECPIntegral(int maxLB, int maxLU, int deriv=0);
+		ECPIntegral(int maxLB, int maxLU, int deriv=0,
+					double thresh = 1e-15, unsigned smallGrid = 256, unsigned bigGrid = 1024);
 	
 		/**
 		  * Calculates the type 1 integrals for the given ECP center over the given shell pair, using quadrature

--- a/src/lib/ecpint.cpp
+++ b/src/lib/ecpint.cpp
@@ -33,7 +33,8 @@
 
 namespace libecpint {
 
-	ECPIntegral::ECPIntegral(const int maxLB, const int maxLU, const int deriv) {
+	ECPIntegral::ECPIntegral(int maxLB, int maxLU, int deriv,
+							 double thresh, unsigned smallGrid, unsigned bigGrid) {
 		// Make sure library can perform requested integrals
 		assert(maxLB+deriv <= LIBECPINT_MAX_L); 
 		assert(maxLU <= LIBECPINT_MAX_L);
@@ -45,7 +46,11 @@ namespace libecpint {
 		// Initialise angular and radial integrators
 		angInts.init(maxLB + deriv, maxLU);
 		angInts.compute();
-		radInts.init(2*(maxLB+deriv) + maxLU, 1e-15, 256, 512);
+#ifdef DEBUG
+		std::cout << "Initializing ECP radial integrator: thresh = " << thresh << "  grids: "
+				<< smallGrid << "/" << bigGrid << std::endl;
+#endif
+		radInts.init(2*(maxLB+deriv) + maxLU, thresh, smallGrid, bigGrid);
 	};
 
 	double ECPIntegral::calcC(const int a, const int m, const double A) const {


### PR DESCRIPTION
I also noticed that you had 1024 points as default for the big grid in the radial constructor, but were passing in 512 in the top-level initializer.