### PR TITLE
Avoiding `gtest` installation when not present in the system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,10 +6,10 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF) #...without compiler extensions like gnu++11
 
-#build type
+# build type
 if(NOT CMAKE_BUILD_TYPE)
-  message(STATUS "No build type specified. Will build Release")
-  set (CMAKE_BUILD_TYPE Release CACHE STRING "Build type (Release/Debug/RelWithDebInfo)")
+  message(STATUS "No build type specified. Will build Release.")
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type (Release/Debug/RelWithDebInfo)")
 else()
   string(TOUPPER "${CMAKE_BUILD_TYPE}" _upper_build_type)
   if("${_upper_build_type}" STREQUAL "DEBUG")
@@ -23,11 +23,11 @@ project( libecpint
          LANGUAGES C CXX)
 
 set(API_VERSION 1)
-set (CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
+set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
 # code generator variables
-set (LIBECPINT_MAX_L "5" CACHE STRING "Maximum angular momentum")
-set (LIBECPINT_MAX_UNROL "1" CACHE STRING "Maximum L for unrolling")
+set(LIBECPINT_MAX_L "5" CACHE STRING "Maximum angular momentum")
+set(LIBECPINT_MAX_UNROL "1" CACHE STRING "Maximum L for unrolling")
 
 # configure the config header to pass the above variables to the program
 configure_file (
@@ -37,6 +37,7 @@ configure_file (
 
 include(GNUInstallDirs)
 include(ExternalProject)
+
 option(LIBECPINT_USE_PUGIXML "Use pugixml and build file reading routines." ON)
 if (LIBECPINT_USE_PUGIXML)
   include(external/ImportPugiXML.cmake)
@@ -50,17 +51,26 @@ add_subdirectory(src)
 
 option(LIBECPINT_BUILD_TESTS "Enables Libecpint tests." ON)
 if (LIBECPINT_BUILD_TESTS)
+  message(STATUS "Will build libecpint tests.")
   include(CTest)
   include(external/ImportGTest.cmake)
   enable_testing()
   add_subdirectory(tests)
 endif()
+
 option(LIBECPINT_BUILD_DOCS "Enables Libecpint documentation." ON)
 if (LIBECPINT_BUILD_DOCS)
   add_subdirectory(doc)
 endif()
 
-install (DIRECTORY include/libecpint DESTINATION include)
-install (FILES include/libecpint.hpp DESTINATION include)
-install (FILES "${CMAKE_CURRENT_BINARY_DIR}/include/libecpint/config.hpp" DESTINATION include/libecpint)
-install (DIRECTORY share/libecpint DESTINATION share)
+install(DIRECTORY include/libecpint DESTINATION include)
+install(FILES include/libecpint.hpp DESTINATION include)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/include/libecpint/config.hpp" DESTINATION include/libecpint)
+install(DIRECTORY share/libecpint DESTINATION share)
+
+message("\nSummary:")
+message("--------")
+message(STATUS "Maximum angular momentum           : ${LIBECPINT_MAX_L}")
+message(STATUS "Maximum angular momentum unrolling : ${LIBECPINT_MAX_UNROL}")
+message(STATUS "Build tests                        : ${LIBECPINT_BUILD_TESTS}")
+message("")

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
 # define project
-project( LibecpintExample 
+project( LibecpintExample
          VERSION 1.0
          LANGUAGES CXX)
 

--- a/external/CMakeLists.txt.in
+++ b/external/CMakeLists.txt.in
@@ -6,10 +6,7 @@ include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
   GIT_TAG           master
-  SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
-  BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
-  CONFIGURE_COMMAND ""
-  BUILD_COMMAND     ""
-  INSTALL_COMMAND   ""
+  INSTALL_DIR       "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
+  CONFIGURE_COMMAND ${CMAKE_COMMAND} -S<SOURCE_DIR> -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
   TEST_COMMAND      ""
 )

--- a/external/ImportGTest.cmake
+++ b/external/ImportGTest.cmake
@@ -6,10 +6,13 @@ find_path(GTEST_INCLUDE_DIR gtest/gtest.h
 )
 
 if((NOT GTEST_LIBRARY) OR (NOT GTEST_INCLUDE_DIR))
-  message(STATUS "Unable to find google test, cloning...")
+  message(STATUS "Unable to find google test, cloning and building ...")
+
+  set(THREADS_REFER_PTHREAD_FLAG "ON")
+  find_package(Threads REQUIRED)
 
   # Download and unpack googletest at configure time
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/external/CMakeLists.txt.in googletest-download/CMakeLists.txt)
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/external/CMakeLists.txt.in ${CMAKE_CURRENT_BINARY_DIR}/googletest-download/CMakeLists.txt)
   execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
     RESULT_VARIABLE result
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
@@ -27,14 +30,12 @@ if((NOT GTEST_LIBRARY) OR (NOT GTEST_INCLUDE_DIR))
   # settings on Windows
   set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
-  # Add googletest directly to our build. This defines
-  # the gtest and gtest_main targets.
-  add_subdirectory(
-    ${CMAKE_CURRENT_BINARY_DIR}/googletest-src
-    ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
-  )
-
-  set(GTEST_INCLUDE_DIR ${gtest_SOURCE_DIR}/include)
+  # Set GTEST interface to temporarily installed libgtest.a
+  set(GTEST_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/googletest-build/include)
+  set(GTEST_LIBRARY ${CMAKE_CURRENT_BINARY_DIR}/googletest-build/lib/libgtest.a)
+  add_library(gtest INTERFACE)
+  target_include_directories(gtest INTERFACE ${GTEST_INCLUDE_DIR})
+  target_link_libraries(gtest INTERFACE ${GTEST_LIBRARY} Threads::Threads)
 else()
   message(STATUS "Found googletest: ${GTEST_INCLUDE_DIR} ${GTEST_LIBRARY}")
   add_library(gtest INTERFACE)

--- a/external/ImportPugiXML.cmake
+++ b/external/ImportPugiXML.cmake
@@ -9,7 +9,7 @@ find_path(PUGIXML_INCLUDE_DIR pugixml.hpp
 )
 
 if((NOT PUGIXML_LIBRARY) OR (NOT PUGIXML_INCLUDE_DIR))
-  message(STATUS "Unable to find pugixml, cloning...")
+  message(STATUS "Unable to find pugixml, cloning and building ...")
 
   ExternalProject_Add(pugixml_external
     PREFIX ${EXTERNAL_BUILD_DIR}/pugixml

--- a/share/libecpint/parseecp.py
+++ b/share/libecpint/parseecp.py
@@ -12,7 +12,7 @@ angular_shells = ["s", "p", "d", "f", "g", "h", "i"]
 class Shell:
     """ Container for a shell of an ECP
         i.e. the Gaussian expansion of a fixed angular momentum
-        
+
         Members:
         lval - angular momentum quantumm number of shell
         powers - the power of r for each Gaussian in the shell
@@ -30,7 +30,7 @@ class Shell:
 
 class Atom:
     """ Container for an ECP for a specific atom type
-        
+
         Members:
         name - name of the atom, e.g. 'O' for oxygen
         ncore - the number of core electrons in the ECP
@@ -45,7 +45,7 @@ class Atom:
         self.maxl = 0
         self.nshells = nshells
         self.shells = []
-        
+
 def tokenize(line, sep=','):
     """Given a line of input, cleans up and returns tokens,
        split by the separator (sep)
@@ -54,28 +54,28 @@ def tokenize(line, sep=','):
     line = line.strip()
     tokens = line.split(sep)
     # get rid of additional whitespace
-    for token in tokens: 
+    for token in tokens:
         token = token.replace(' ', '')
     return tokens
-        
+
 def parse_ecp(file):
     """Given a MOLPRO-format ECP file, returns Atom objects (ECPs) for every
-       atom type defined in that file.  
+       atom type defined in that file.
     """
     atoms = []
     atomnames = {}
-    
+
     # read in the file
     lines = file.readlines()
     nlines = len(lines)
-    
+
     # loop to the end of the file
     linenumber = 0
     atomnumber = 0
     while linenumber < nlines:
         tokens = tokenize(lines[linenumber], sep=',')
-        
-        # all lines where ECP definitions start will have 
+
+        # all lines where ECP definitions start will have
         # at least two bits "ecp,AtomName"
         if (len(tokens) > 2):
             if (tokens[0].lower() == "ecp"):
@@ -89,11 +89,11 @@ def parse_ecp(file):
                 new_atom.ncore = int(tokens[2])
                 new_atom.maxl = int(tokens[3])
                 # there should then be maxl+1 lines definining the shells
-                # in the order [maxL, 0, 1, ..., maxL-1]                
+                # in the order [maxL, 0, 1, ..., maxL-1]
                 for i in range(new_atom.maxl+1):
                     linenumber += 1
                     tokens = tokenize(lines[linenumber], sep=';')
-                    
+
                     # could be blank lines or comments, so check first
                     if(len(tokens) > 1):
                         # shell definition has form "nx; n,x,c; n,x,c; ..."
@@ -102,7 +102,7 @@ def parse_ecp(file):
                         l = i-1
                         if (i==0):
                             l = new_atom.maxl
-                        
+
                         # create a container for the shell
                         new_shell = Shell(lval=l, nexp=nprims)
                         # fill in the details of the shell as described above
@@ -112,23 +112,23 @@ def parse_ecp(file):
                                 new_shell.powers.append(subtokens[0])
                                 new_shell.exps.append(subtokens[1])
                                 new_shell.contr.append(subtokens[2])
-                        
+
                         # append the new shell to the Atom
                         new_atom.shells.append(new_shell)
                 # end of Atom definition, append
                 atoms.append(new_atom)
-                
+
         linenumber += 1
-    
+
     # Return all the atoms found
     return atoms
 
 def write_ecp_basis(atoms, name):
     """Given a list of Atom objects defining ECPs, and a name for the ECP basis,
-       this writes the basis to XML file. 
+       this writes the basis to XML file.
     """
     filename = "xml/" + name + ".xml"
-    
+
     # write into a binary xml file using LXML package
     with open(filename, 'wb') as new_file:
         # format is Root -> Atom1 --> Shell1
@@ -136,13 +136,13 @@ def write_ecp_basis(atoms, name):
         #                   Atom2 --> etc.
         root = etree.Element("root", name=name)
         tree = etree.ElementTree(root)
-        
+
         for atom in atoms:
             child = etree.SubElement(root, atom.name, ncore = str(atom.ncore), maxl=str(atom.maxl))
-            
+
             for shell in atom.shells:
                 schild = etree.SubElement(child, "Shell", lval=str(shell.lval), nexp=str(shell.nexp))
-                
+
                 for i in range(shell.nexp):
                     try:
                         xchild = etree.SubElement(schild, "nxc", n=shell.powers[i], x=shell.exps[i], c=shell.contr[i])
@@ -162,4 +162,3 @@ if __name__ == "__main__":
     input_file = open('raw/' + name + '.ecp', 'r')
     atoms = parse_ecp(input_file)
     write_ecp_basis(atoms, name)
-    

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,9 +3,11 @@
 #  Target: generate
 # ==================
 
-add_executable(generate generate.cpp
-			lib/mathutil.cpp
-			lib/angular.cpp)
+add_executable(generate
+               generate.cpp
+               lib/mathutil.cpp
+               lib/angular.cpp)
+
 set_property(TARGET generate PROPERTY CXX_STANDARD 11)
 target_include_directories(generate
   PRIVATE
@@ -50,10 +52,12 @@ target_include_directories(ecpint
     $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include/libecpint>
     $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>
 )
+
 target_link_libraries(ecpint
  PRIVATE
   Faddeeva
 )
+
 if(LIBECPINT_USE_PUGIXML)
   target_include_directories(ecpint PRIVATE ${PUGIXML_INCLUDE_DIR})
   target_link_libraries(ecpint PRIVATE libpugixml)

--- a/src/generate.cpp
+++ b/src/generate.cpp
@@ -1,6 +1,6 @@
-/* 
+/*
 *      Copyright (c) 2020 Robert Shaw
-*		This file is a part of Libecpint.
+       This file is a part of Libecpint.
 *
 *      Permission is hereby granted, free of charge, to any person obtaining
 *      a copy of this software and associated documentation files (the

--- a/src/makelist.py
+++ b/src/makelist.py
@@ -1,5 +1,5 @@
 # takes the arguments of max angular momentum
-# and file prefix, then generates a list of all the 
+# and file prefix, then generates a list of all the
 # CPP files that will be generateds
 
 import sys
@@ -12,7 +12,7 @@ for j in range(max_am+1):
     for i in range(j+1):
         for k in range(max_am+1):
             if j == i == k == max_am:
-                file.write(prefix + "/generated/Q" + str(i) + str(j) + str(k) + ".cpp") 
+                file.write(prefix + "/generated/Q" + str(i) + str(j) + str(k) + ".cpp")
             else:
                 file.write(prefix + "/generated/Q" + str(i) + str(j) + str(k) + ".cpp\n")
 file.close()


### PR DESCRIPTION
Currently, if `gtest` is not found in the system, it is fetched and built by `cmake` in order to build `libecpint` tests by adding `gtest` to the `libecpint` library target. This forces `cmake` to install `gtest` to the system, even though it is only needed for the test binaries. Despite this not being a problem in general, I've had issues recompiling `libecpint` after `gtest` was installed via this mechanism, and thus think that it might be a good idea to disable it.

This pull request addresses this issue by installing `gtest` in the build directory instead, and loading it as an interface, which prevents `cmake` from installing it to the `CMAKE_INSTALL_PREFIX`.

