### PR TITLE
Do not use `#cmakedefine` for `LIBECPINT_MAX_UNROL`

### DIFF
--- a/include/libecpint/config.hpp.in
+++ b/include/libecpint/config.hpp.in
@@ -29,6 +29,6 @@
 #cmakedefine LIBECPINT_MAX_L @LIBECPINT_MAX_L@
 
 // Angular momentum below which integrals are unrolled
-#cmakedefine LIBECPINT_MAX_UNROL @LIBECPINT_MAX_UNROL@
+#define LIBECPINT_MAX_UNROL @LIBECPINT_MAX_UNROL@
 
 #endif


### PR DESCRIPTION
If `LIBECPINT_MAX_UNROL` is zero, the corresponding macro is not defined by `#cmakedefine`:
```cpp
/* #undef LIBECPINT_MAX_UNROL */
```

This leads to compilation error.