### PR TITLE
cmake: migrate C++ standard to targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,6 @@
 cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
 include(CheckCXXCompilerFlag)
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF) #...without compiler extensions like gnu++11
 
 # build type
 if(NOT CMAKE_BUILD_TYPE)

--- a/external/Faddeeva/CMakeLists.txt
+++ b/external/Faddeeva/CMakeLists.txt
@@ -1,6 +1,6 @@
 if (NOT LIBECPINT_USE_CERF)
 add_library(Faddeeva Faddeeva.cpp)
-set_property(TARGET Faddeeva PROPERTY CXX_STANDARD 11)
+target_compile_features(Faddeeva PUBLIC cxx_std_11)
 set_target_properties(Faddeeva PROPERTIES SOVERSION ${API_VERSION})
 target_include_directories(Faddeeva
   PUBLIC

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,7 +8,7 @@ add_executable(generate
                lib/mathutil.cpp
                lib/angular.cpp)
 
-set_property(TARGET generate PROPERTY CXX_STANDARD 11)
+target_compile_features(generate PUBLIC cxx_std_11)
 target_include_directories(generate
   PRIVATE
     ${PROJECT_SOURCE_DIR}/include
@@ -42,7 +42,7 @@ if(NOT BUILD_SHARED_LIBS)
   set_property(TARGET ecpint PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()
 
-set_property(TARGET ecpint PROPERTY CXX_STANDARD 11)
+target_compile_features(ecpint PUBLIC cxx_std_11)
 set_target_properties(ecpint PROPERTIES SOVERSION ${API_VERSION})
 target_include_directories(ecpint
   PUBLIC


### PR DESCRIPTION
Fix #58 