### PR TITLE
cmake: remove unused requirement for C compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ endif(NOT CMAKE_BUILD_TYPE)
 # define project
 project( libecpint
          VERSION 1.0.7
-         LANGUAGES C CXX)
+         LANGUAGES CXX)
 
 set(API_VERSION 1)
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})


### PR DESCRIPTION
This is only required when there are files in the parent project which require a <language> compiler.