### PR TITLE
build/CI: restore CI (Azure image + GoogleTest) and fix GoogleTest lib64 path

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ jobs:
 - job: 'linux_build'
   displayName: 'Linux Builds'
   pool:
-    vmImage: 'ubuntu-20.04'
+    vmImage: 'ubuntu-22.04'
   timeoutInMinutes: 10
   variables:
     CTEST_OUTPUT_ON_FAILURE: 1
@@ -26,7 +26,7 @@ jobs:
         C_COMPILER: 'clang'
         F_COMPILER: 'gfortran'
         BUILD_TYPE: 'release'
-        APT_INSTALL: 'gfortran clang-10'
+        APT_INSTALL: 'gfortran clang'
 
   steps:
   - checkout: self

--- a/external/CMakeLists.txt.in
+++ b/external/CMakeLists.txt.in
@@ -5,7 +5,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           main
+  GIT_TAG           v1.14.0
   INSTALL_DIR       "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ${CMAKE_COMMAND} -S<SOURCE_DIR> -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR> -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR}
   TEST_COMMAND      ""

--- a/external/ImportGTest.cmake
+++ b/external/ImportGTest.cmake
@@ -30,9 +30,19 @@ if((NOT GTEST_LIBRARY) OR (NOT GTEST_INCLUDE_DIR))
   # settings on Windows
   set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
-  # Set GTEST interface to temporarily installed libgtest.a
+  # Set GTEST interface to temporarily installed libgtest.a.
+  # googletest installs to lib or lib64 depending on the platform (e.g. lib64 on Fedora/RHEL),
+  # so locate the freshly built archive rather than assuming a fixed path.
   set(GTEST_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/googletest-build/include)
-  set(GTEST_LIBRARY ${CMAKE_CURRENT_BINARY_DIR}/googletest-build/lib/libgtest.a)
+  find_library(GTEST_LIBRARY
+    NAMES gtest
+    PATHS "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
+    PATH_SUFFIXES lib lib64
+    NO_DEFAULT_PATH
+  )
+  if(NOT GTEST_LIBRARY)
+    message(FATAL_ERROR "Could not locate the freshly built libgtest under googletest-build/{lib,lib64}")
+  endif()
   add_library(gtest INTERFACE)
   target_include_directories(gtest INTERFACE ${GTEST_INCLUDE_DIR})
   target_link_libraries(gtest INTERFACE ${GTEST_LIBRARY} Threads::Threads)


### PR DESCRIPTION
Three small, self-contained build/CI-infrastructure fixes (`azure-pipelines.yml`, `external/CMakeLists.txt.in`, `external/ImportGTest.cmake`), independent of the other PRs. Together they get CI green again — it was failing for everyone.

### 1. Azure pipeline image (routing failure)
`vmImage: 'ubuntu-20.04'` has been retired by Azure, so every build failed to route an agent (`No image label found to route agent pool Azure Pipelines`). Bumped to `ubuntu-22.04` and dropped the explicit `clang-10` (not packaged there; the job uses the default `clang`/`clang++`).

### 2. GoogleTest pin (clang build failure)
The external GoogleTest was pinned to the moving tag `main`, which now requires C++17; the clang job compiles with `-std=c++14` and broke with `#error C++ versions less than C++17 are not supported` (gcc passed only because its job sets no `-std` and defaults to C++17). Pinned to released `v1.14.0`, which supports C++14 and makes the dependency reproducible.

### 3. GoogleTest lib64 path
`ImportGTest.cmake` hard-coded `googletest-build/lib/libgtest.a`; GoogleTest installs to `lib64` on Fedora/RHEL-style systems, so unit tests failed to link there. Now locates the archive under `lib` or `lib64`.

Verified locally: clang `-std=c++14` and gcc both build clean and pass the suite. Worth merging first — it unblocks CI for the stacked fix/hardening/performance PRs (#71–#73).

🤖 Generated with [Claude Code](https://claude.com/claude-code)