### PR TITLE
Fix azure-pipelines workflow 

### DIFF
--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -1,23 +1,25 @@
-on: [push]
+on:
+  workflow_dispatch:
+
 
 jobs:
   paper:
     runs-on: ubuntu-latest
     name: Paper Draft
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build draft PDF
-        uses: openjournals/openjournals-draft-action@master
-        with:
-          journal: joss
-          # This should be the path to the paper within your repo.
-          paper-path: doc/joss/paper.md
-      - name: Upload
-        uses: actions/upload-artifact@v1
-        with:
-          name: paper
-          # This is the output path where Pandoc will write the compiled
-          # PDF. Note, this should be the same directory as the input
-          # paper.md
-          path: doc/joss/paper.pdf
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Build draft PDF
+      uses: openjournals/openjournals-draft-action@master
+      with:
+        journal: joss
+        # This should be the path to the paper within your repo.
+        paper-path: doc/joss/paper.md
+    - name: Upload
+      uses: actions/upload-artifact@v4
+      with:
+        name: paper
+        # This is the output path where Pandoc will write the compiled
+        # PDF. Note, this should be the same directory as the input
+        # paper.md
+        path: doc/joss/paper.pdf

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,18 +26,23 @@ jobs:
         C_COMPILER: 'clang'
         F_COMPILER: 'gfortran'
         BUILD_TYPE: 'release'
-        APT_INSTALL: 'gfortran clang-10'
+        APT_INSTALL: 'gfortran clang'
 
   steps:
   - checkout: self
     submodules: true
     displayName: "Checkout repos"
   - bash: |
+      set -euo pipefail
       [[ "${APT_REPOSITORY}" ]] && echo "Add Repo ${APT_REPOSITORY}" && sudo add-apt-repository "${APT_REPOSITORY}"
       sudo apt-get update
-      sudo apt-get install ${APT_INSTALL}
+      sudo apt-get install -y ${APT_INSTALL}
     displayName: "Apt-Get Packages"
   - bash: |
+      set -euo pipefail
+      command -v ${CXX_COMPILER}
+      command -v ${C_COMPILER}
+      command -v ${F_COMPILER}
       echo "" && echo "Ubuntu"
       lsb_release -a
       echo "" && echo "Uname:"
@@ -58,20 +63,23 @@ jobs:
       ${C_COMPILER} --version
     displayName: 'Build Environment'
   - bash: |
-      cmake -Bbuild -H. \
+      set -euo pipefail
+      cmake -S . -B build \
+        -DCMAKE_C_COMPILER=${C_COMPILER} \
+        -DCMAKE_CXX_COMPILER=${CXX_COMPILER} \
+        -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
         -DCMAKE_INSTALL_PREFIX=$(Agent.BuildDirectory)/Install \
         -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" \
         -DLIBECPINT_MAX_UNROL=1 \
         -DLIBECPINT_MAX_L=4
     displayName: 'Configure Build'
   - bash: |
-      cd build
-      make all
+      set -euo pipefail
+      cmake --build build --parallel
     displayName: 'Build'
   - bash: |
-      cd build
-      make test
+      set -euo pipefail
+      ctest --test-dir build --output-on-failure
     displayName: 'Tests'
-  - bash:
-      bash <(curl -s https://codecov.io/bash)
+  - bash: bash <(curl -s https://codecov.io/bash)
     displayName: 'Upload to codecov.io'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,13 @@
+parameters:
+- name: fullRun
+  displayName: Run full build and tests
+  type: boolean
+  default: false
+
 trigger:
+- master
+
+pr:
 - master
 
 jobs:
@@ -34,7 +43,7 @@ jobs:
     displayName: "Checkout repos"
   - bash: |
       set -euo pipefail
-      [[ "${APT_REPOSITORY}" ]] && echo "Add Repo ${APT_REPOSITORY}" && sudo add-apt-repository "${APT_REPOSITORY}"
+      [[ -n "${APT_REPOSITORY:-}" ]] && echo "Add Repo ${APT_REPOSITORY}" && sudo add-apt-repository "${APT_REPOSITORY}"
       sudo apt-get update
       sudo apt-get install -y ${APT_INSTALL}
     displayName: "Apt-Get Packages"
@@ -43,6 +52,8 @@ jobs:
       command -v ${CXX_COMPILER}
       command -v ${C_COMPILER}
       command -v ${F_COMPILER}
+      echo "Full run requested: ${{ parameters.fullRun }}"
+      echo "Build reason: $(Build.Reason)"
       echo "" && echo "Ubuntu"
       lsb_release -a
       echo "" && echo "Uname:"
@@ -77,9 +88,12 @@ jobs:
       set -euo pipefail
       cmake --build build --parallel
     displayName: 'Build'
+    condition: and(succeeded(), or(ne(variables['Build.Reason'], 'PullRequest'), ${{ eq(parameters.fullRun, true) }}))
   - bash: |
       set -euo pipefail
       ctest --test-dir build --output-on-failure
     displayName: 'Tests'
+    condition: and(succeeded(), or(ne(variables['Build.Reason'], 'PullRequest'), ${{ eq(parameters.fullRun, true) }}))
   - bash: bash <(curl -s https://codecov.io/bash)
     displayName: 'Upload to codecov.io'
+    condition: and(succeeded(), or(ne(variables['Build.Reason'], 'PullRequest'), ${{ eq(parameters.fullRun, true) }}))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ jobs:
 - job: 'linux_build'
   displayName: 'Linux Builds'
   pool:
-    vmImage: 'ubuntu-20.04'
+    vmImage: 'ubuntu-latest'
   timeoutInMinutes: 10
   variables:
     CTEST_OUTPUT_ON_FAILURE: 1


### PR DESCRIPTION
Azure builds are failing because of error "no image label found to route agent pool azure pipelines". Update the image to `ubuntu-latest` to fix.