### PR TITLE
Fix clang build on azure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ endif(NOT CMAKE_BUILD_TYPE)
 # define project
 project( libecpint
          VERSION 1.0.7
-         LANGUAGES C CXX)
+         LANGUAGES CXX)
 
 set(API_VERSION 1)
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ jobs:
 
       clang_latest:
         CXX_COMPILER: 'clang++'
-        CXX_FLAGS: "-O3 -std=c++14"
+        CXX_FLAGS: "-O3 -std=c++17"
         C_COMPILER: 'clang'
         F_COMPILER: 'gfortran'
         BUILD_TYPE: 'release'


### PR DESCRIPTION
Googletest has bumped it's C++ requirement to c++17, breaking the clang build path on azure.